### PR TITLE
BUG: Fix /go links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog for plugin *topobank-publication*
 
-## 1.5.1 (not yet released)
+## 1.6.0 (2024-01-26)
 
+- ENH: /go links return API redirect if `application/json` is requested,
+  otherwise HTML redirect
+- ENH: API endpoint for publication now returns download link
+- BUG: Fix to /go links, which in latest version redirect to API endpoint
+  only
 - MAINT: Adding gitignore
 
 ## 1.5.0 (2024-01-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@
 ## 1.6.0 (2024-01-26)
 
 - ENH: /go links return API redirect if `application/json` is requested,
-  otherwise HTML redirect
+  otherwise HTML redirect (#9)
 - ENH: API endpoint for publication now returns download link
-- BUG: Fix to /go links, which in latest version redirect to API endpoint
-  only
+- BUG: Fix to /go links (#8)
 - MAINT: Adding gitignore
 
 ## 1.5.0 (2024-01-20)

--- a/topobank_publication/models.py
+++ b/topobank_publication/models.py
@@ -10,6 +10,8 @@ from django.utils.http import quote
 from django.http.request import urljoin
 from django.conf import settings
 
+from rest_framework.reverse import reverse
+
 from datacite import schema42, DataCiteRESTClient
 from datacite.errors import DataCiteError, HttpError
 

--- a/topobank_publication/models.py
+++ b/topobank_publication/models.py
@@ -10,8 +10,6 @@ from django.utils.http import quote
 from django.http.request import urljoin
 from django.conf import settings
 
-from rest_framework.reverse import reverse
-
 from datacite import schema42, DataCiteRESTClient
 from datacite.errors import DataCiteError, HttpError
 

--- a/topobank_publication/models.py
+++ b/topobank_publication/models.py
@@ -67,6 +67,9 @@ class Publication(models.Model):
     def get_absolute_url(self):
         return reverse('publication:go', args=[self.short_url])
 
+    def get_api_url(self):
+        return reverse('publication:publication-api-detail', kwargs={'pk': self.pk})
+
     def get_full_url(self):
         """Return URL which should be used to permanently point to this publication.
 

--- a/topobank_publication/serializers.py
+++ b/topobank_publication/serializers.py
@@ -1,5 +1,3 @@
-from django.urls import reverse
-
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 

--- a/topobank_publication/serializers.py
+++ b/topobank_publication/serializers.py
@@ -1,4 +1,7 @@
+from django.urls import reverse
+
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
 from topobank.users.serializers import UserSerializer
 
@@ -20,11 +23,11 @@ class PublicationSerializer(serializers.HyperlinkedModelSerializer):
                   'license',
                   'authors_json',
                   'datacite_json',
-                  'container',
                   'doi_name',
                   'doi_state',
                   'citation',
-                  'has_access_to_original_surface']
+                  'has_access_to_original_surface',
+                  'download_url']
 
     url = serializers.HyperlinkedIdentityField(view_name='publication:publication-api-detail', read_only=True)
     surface = serializers.HyperlinkedRelatedField(view_name='manager:surface-api-detail', read_only=True)
@@ -32,6 +35,7 @@ class PublicationSerializer(serializers.HyperlinkedModelSerializer):
     publisher = UserSerializer(read_only=True)
     citation = serializers.SerializerMethodField()
     has_access_to_original_surface = serializers.SerializerMethodField()
+    download_url = serializers.SerializerMethodField()
 
     def get_citation(self, obj):
         d = {}
@@ -41,3 +45,8 @@ class PublicationSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_has_access_to_original_surface(self, obj):
         return self.context['request'].user.has_perm('view_surface', obj.original_surface)
+
+    def get_download_url(self, obj):
+        return reverse('manager:surface-download',
+                       kwargs={'surface_id': obj.surface.id},
+                       request=self.context['request'])

--- a/topobank_publication/tests/test_api.py
+++ b/topobank_publication/tests/test_api.py
@@ -9,4 +9,3 @@ def test_api():
     assert reverse('publication:surface-publication-error',
                    kwargs=dict(pk=123)) == '/go/html/publish/123/publication-error/'
     assert reverse('publication:go', kwargs=dict(short_url='abc123')) == '/go/abc123/'
-    assert reverse('publication:go-download', kwargs=dict(short_url='abc123')) == '/go/abc123/download/'

--- a/topobank_publication/tests/test_views.py
+++ b/topobank_publication/tests/test_views.py
@@ -13,21 +13,45 @@ from topobank.utils import assert_in_content
 
 
 @pytest.mark.django_db
-def test_go_link(client, example_pub):
+def test_go_link_html(client, example_pub):
+    # The normal client send not header
     user = UserFactory()
     client.force_login(user)
     url = reverse('publication:go', kwargs=dict(short_url=example_pub.short_url))
     assert url == f'/go/{example_pub.short_url}/'
     response = client.get(url, follow=False)
     assert response.status_code == 302
-    assert response.url.endswith(f'{example_pub.surface.id}/')
+    assert response.url.endswith(f'?surface={example_pub.surface.id}')
 
 
 @pytest.mark.django_db
-def test_go_download_link(client, example_pub, handle_usage_statistics):
+def test_go_link_api(api_client, example_pub, handle_usage_statistics):
+    # We send a header with HTTP_ACCEPT application/json to get the API response
     user = UserFactory()
-    client.force_login(user)
-    response = client.get(reverse('publication:go-download', kwargs=dict(short_url=example_pub.short_url)), follow=True)
+    api_client.force_login(user)
+    url = reverse('publication:go', kwargs=dict(short_url=example_pub.short_url))
+    assert url == f'/go/{example_pub.short_url}/'
+    response = api_client.get(url, follow=False, HTTP_ACCEPT='application/json')
+    assert response.status_code == 302
+    assert response.url.endswith(f'api/publication/{example_pub.id}/')
+
+    response = api_client.get(url, follow=True, HTTP_ACCEPT='application/json')
+    assert response.status_code == 200
+    assert response.data['url'].endswith(f'api/publication/{example_pub.id}/')
+    assert response.data['surface'].endswith(f'api/surface/{example_pub.surface.id}/')
+    assert response.data['short_url'] == example_pub.short_url
+
+
+@pytest.mark.django_db
+def test_go_download(api_client, example_pub, handle_usage_statistics):
+    user = UserFactory()
+    api_client.force_login(user)
+    url = reverse('publication:go', kwargs=dict(short_url=example_pub.short_url))
+    assert url == f'/go/{example_pub.short_url}/'
+    response = api_client.get(url, follow=True, HTTP_ACCEPT='application/json')
+    assert response.status_code == 200
+
+    response = api_client.get(response.data['download_url'], follow=True)
     assert response.status_code == 200
 
     surface = example_pub.surface

--- a/topobank_publication/urls.py
+++ b/topobank_publication/urls.py
@@ -32,10 +32,5 @@ urlpatterns += [
         '<str:short_url>/',
         view=views.go,
         name='go'
-    ),
-    path(
-        '<str:short_url>/download/',
-        view=views.download,
-        name='go-download'
     )
 ]

--- a/topobank_publication/views.py
+++ b/topobank_publication/views.py
@@ -65,17 +65,11 @@ def go(request, short_url):
         raise Http404()
 
     increase_statistics_by_date_and_object(Metric.objects.PUBLICATION_VIEW_COUNT, period=Period.DAY, obj=pub)
-    return redirect(pub.surface.get_absolute_url())
 
-
-def download(request, short_url):
-    """Download a published surface by short url."""
-    try:
-        pub = Publication.objects.get(short_url=short_url)
-    except Publication.DoesNotExist:
-        raise Http404()
-
-    return download_surface(request, pub.surface_id)
+    if 'application/json' in request.META['HTTP_ACCEPT']:
+        return redirect(pub.get_api_url())
+    else:
+        return redirect(f"{reverse('ce_ui:surface-detail')}?surface={pub.surface.pk}")  # <- topobank does not know this
 
 
 class SurfacePublishView(FormView):

--- a/topobank_publication/views.py
+++ b/topobank_publication/views.py
@@ -66,7 +66,7 @@ def go(request, short_url):
 
     increase_statistics_by_date_and_object(Metric.objects.PUBLICATION_VIEW_COUNT, period=Period.DAY, obj=pub)
 
-    if 'application/json' in request.META['HTTP_ACCEPT']:
+    if 'HTTP_ACCEPT' in request.META and 'application/json' in request.META['HTTP_ACCEPT']:
         return redirect(pub.get_api_url())
     else:
         return redirect(f"{reverse('ce_ui:surface-detail')}?surface={pub.surface.pk}")  # <- topobank does not know this

--- a/topobank_publication/views.py
+++ b/topobank_publication/views.py
@@ -20,7 +20,6 @@ from .serializers import PublicationSerializer
 from .utils import NewPublicationTooFastException, PublicationException
 
 from topobank.manager.models import Surface
-from topobank.manager.views import download_surface
 from topobank.usage_stats.utils import increase_statistics_by_date_and_object
 
 _log = logging.getLogger(__name__)


### PR DESCRIPTION
The shorthand /go links currently point to the API, which does not make sense. This PR implements a redirect to API only if `application/json` is requested, otherwise it will redirect to the HTML page.