### PR TITLE
Update fontawesome tag usage to version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for plugin *topobank-publication*
 
+## 1.7.1 (to be released)
+
+- BUG: Update used icons to fontawesome 6
+
 ## 1.7.0 (2024-11-13)
 
 - MAINT: Updates for API changes in topobank 1.50.0

--- a/topobank_publication/templates/license_urls.html
+++ b/topobank_publication/templates/license_urls.html
@@ -2,9 +2,9 @@
 {% load icon_tags %}
 <span>
  <a class="alert-link" href="{{ description_url }}" target="_blank">
-   {% fa5_icon 'external-link-alt' %} Description
+   {% fa6_icon 'up-right-from-square' %} Description
  </a>
  <a class="alert-link" href="{{ legal_code_url }}" target="_blank">
-   {% fa5_icon 'external-link-alt' %} Legal code
+   {% fa6_icon 'up-right-from-square' %} Legal code
  </a>
 </span>

--- a/topobank_publication/templates/multi_author_field.html
+++ b/topobank_publication/templates/multi_author_field.html
@@ -20,7 +20,7 @@
             type="button"
             id="one_more_author_btn" {# for testing purpose, see splinter tests #}
             v-on:click="add_author(num_authors)">
-        {% fa5_icon 'plus' %} One more author
+        {% fa6_icon 'plus' %} One more author
       </button>
       <input type="hidden" name="authors_json" v-bind:value="authors_json">
     </div>

--- a/topobank_publication/templates/publication_error.html
+++ b/topobank_publication/templates/publication_error.html
@@ -5,7 +5,7 @@
 
 <div class="card">
  <h3 class="card-header">
-   {% fa5_icon 'bolt' %}
+   {% fa6_icon 'bolt' %}
    Publication error for given surface
  </h3>
  <div class="card-body">

--- a/topobank_publication/templates/publication_rate_too_high.html
+++ b/topobank_publication/templates/publication_rate_too_high.html
@@ -5,7 +5,7 @@
 
 <div class="card">
  <h3 class="card-header">
-   {% fa5_icon 'bolt' %}
+   {% fa6_icon 'bolt' %}
    Publication rate limited for given surface
  </h3>
  <div class="card-body">

--- a/topobank_publication/templates/surface_publish.html
+++ b/topobank_publication/templates/surface_publish.html
@@ -54,7 +54,7 @@
           <div class="col">
             <a class="btn btn-default alert-link"
                href="{% url 'manager:topography-create' surface.id %}">
-              {% fa5_icon 'plus-square-o' %} Add measurement
+              {% fa6_icon 'square-plus' %} Add measurement
             </a>
           </div>
         </div>
@@ -165,21 +165,21 @@
                       title="Delete this affiliation"
                       type="button"
                       v-bind:class="{ disabled: $parent.num_affiliations==1 }"
-                      @click="$parent.delete_affiliation(affiliation_idx)">{% fa5_icon 'trash' %}</button>
+                      @click="$parent.delete_affiliation(affiliation_idx)">{% fa6_icon 'trash' %}</button>
               <button class="btn btn-sm btn-secondary"
                       title="Move this affiliation up"
                       type="button"
                       v-bind:class="{ disabled: affiliation_idx==0 }"
-                      @click="$parent.move_affiliation_up(affiliation_idx)">{% fa5_icon 'arrow-up' %}</button>
+                      @click="$parent.move_affiliation_up(affiliation_idx)">{% fa6_icon 'arrow-up' %}</button>
               <button class="btn btn-sm btn-secondary"
                       title="Move this affiliation down"
                       type="button"
                       v-bind:class="{ disabled: affiliation_idx==$parent.num_affiliations-1 }"
-                      @click="$parent.move_affiliation_down(affiliation_idx)">{% fa5_icon 'arrow-down' %}</button>
+                      @click="$parent.move_affiliation_down(affiliation_idx)">{% fa6_icon 'arrow-down' %}</button>
               {#<button class="btn btn-sm btn-secondary"#}
               {#        title="Add an affiliation"#}
               {#        type="button"#}
-              {#        @click="$parent.add_affiliation(affiliation_idx+1)">{% fa5_icon 'university' %}#}
+              {#        @click="$parent.add_affiliation(affiliation_idx+1)">{% fa6_icon 'building-columns' %}#}
               {#        </button>#}
             </div>
           </div>
@@ -220,26 +220,26 @@
                           title="Delete this author"
                           type="button"
                           v-bind:class="{ disabled: $parent.num_authors==1 }"
-                          @click="$parent.delete_author(author_idx)">{% fa5_icon 'trash' %}</button>
+                          @click="$parent.delete_author(author_idx)">{% fa6_icon 'trash' %}</button>
                   <button class="btn btn-secondary insert-me-btn"
                           title="Insert your name and ORCID ID as author"
                           type="button"
                           v-bind:class="{ }"
-                          @click="$parent.insert_user_as_author(author_idx)">{% fa5_icon 'address-card' %}</button>
+                          @click="$parent.insert_user_as_author(author_idx)">{% fa6_icon 'address-card' %}</button>
                   <button class="btn btn-secondary"
                           title="Move this author up"
                           type="button"
                           v-bind:class="{ disabled: author_idx==0 }"
-                          @click="$parent.move_author_up(author_idx)">{% fa5_icon 'arrow-up' %}</button>
+                          @click="$parent.move_author_up(author_idx)">{% fa6_icon 'arrow-up' %}</button>
                   <button class="btn btn-secondary"
                           title="Move this author down"
                           type="button"
                           v-bind:class="{ disabled: author_idx==$parent.num_authors-1 }"
-                          @click="$parent.move_author_down(author_idx)">{% fa5_icon 'arrow-down' %}</button>
+                          @click="$parent.move_author_down(author_idx)">{% fa6_icon 'arrow-down' %}</button>
                   {#<button class="btn btn-secondary"#}
                   {#        title="Add one author"#}
                   {#        type="button"#}
-                  {#        @click="$parent.add_author(author_idx+1)">{% fa5_icon 'user-plus' %}</button>#}
+                  {#        @click="$parent.add_author(author_idx+1)">{% fa6_icon 'user-plus' %}</button>#}
                 </div>
                 </div>
               </div>
@@ -258,7 +258,7 @@
                   <button class="btn btn-sm btn-secondary"
                     title="One more affiliation"
                     type="button"
-                    @click="add_affiliation(num_affiliations)">{% fa5_icon 'plus' %}One more affiliation for this author
+                    @click="add_affiliation(num_affiliations)">{% fa6_icon 'plus' %}One more affiliation for this author
                     </button>
                 </ol>
               </div>

--- a/topobank_publication/views.py
+++ b/topobank_publication/views.py
@@ -160,14 +160,14 @@ class PublicationRateTooHighView(TemplateView):
             {
                 "title": f"{surface.label}",
                 "icon": "gem",
-                "icon_style_prefix": "far",
+                "icon_style_prefix": "fa-regular",
                 "href": f"{reverse('ce_ui:surface-detail')}?surface={surface.pk}",
                 "active": False,
                 "tooltip": f"Properties of surface '{surface.label}'",
             },
             {
                 "title": "Publication rate too high",
-                "icon": "flash",
+                "icon": "bolt",
                 "href": self.request.path,
                 "active": True,
             },
@@ -188,14 +188,14 @@ class PublicationErrorView(TemplateView):
             {
                 "title": f"{surface.label}",
                 "icon": "gem",
-                "icon_style_prefix": "far",
+                "icon_style_prefix": "fa-regular",
                 "href": f"{reverse('ce_ui:surface-detail')}?surface={surface.pk}",
                 "active": False,
                 "tooltip": f"Properties of surface '{surface.label}'",
             },
             {
                 "title": "Publication error",
-                "icon": "flash",
+                "icon": "bolt",
                 "href": self.request.path,
                 "active": True,
             },


### PR DESCRIPTION
This updates the usage of the fontawesome template tag to version 6.

Only merge after corrisponding [PR](https://github.com/ContactEngineering/ce-ui/pull/87) in ce-ui repo is merged.
