### PR TITLE
FIX: return ratelimit time in error response

### DIFF
--- a/topobank_publication/views.py
+++ b/topobank_publication/views.py
@@ -65,7 +65,9 @@ def publish(request):
         publication = Publication.publish(surface, license, request.user, authors)
         return Response({"dataset_id": publication.surface.id})
     except NewPublicationTooFastException as rate_limit_exception:
-        return HttpResponse(status=429, reason=f"{rate_limit_exception._wait_seconds}")
+        return HttpResponse(
+            status=429, content=str.encode(f"{rate_limit_exception._wait_seconds}")
+        )
     except PublicationException as exc:
         msg = f"Publication failed, reason: {exc}"
         _log.error(msg)


### PR DESCRIPTION
When running publishing to fast (rate limit) the remaining seconds is not displayed in the toast message.
This is due to the data not being planced properly in the error response.
This PR fixes this