### PR TITLE
Adapt container tests to index.json; restore autouse DB access; sync .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ splinter_tests.*/
 
 # Django stuff:
 staticfiles/
+static/
 
 # Sphinx documentation
 docs/_build/
@@ -367,3 +368,19 @@ compose/local/django/pip-packages/*
 data/
 .envs/.local/.pypi-authfile
 
+# *.ttf and *.woff2 files
+static/js/*.ttf
+static/js/*.woff2
+
+# *.js files
+static/js/*.js
+
+.env
+
+# Shared project data paths (homogenized across ContactEngineering repos)
+data-lake
+topographies
+topobank/analysis/tests/topographies
+
+# Legacy docker-based generated pip packages
+docker/local/django/pip-packages/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,12 @@ _log = logging.getLogger(__name__)
 settings.SHORT_URL_OFFSET = 1000000
 
 
+@pytest.fixture(autouse=True)
+def _enable_db_access_for_all_tests(db):
+    """Restore the implicit DB access previously provided by the removed
+    autouse `sync_workflows` fixture in topobank.testing.fixtures."""
+
+
 @pytest.fixture
 def example_pub(db, example_authors):  # noqa: F811
     """Fixture returning a publication which can be used as test example."""

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -8,7 +8,7 @@ import zipfile
 
 import pytest
 import topobank
-import yaml
+import json
 from django.conf import settings
 from django.test import override_settings
 from topobank.manager.export_zip import export_container_zip
@@ -83,18 +83,20 @@ def test_surface_container(example_authors, django_capture_on_commit_callbacks):
 
     # reopen and check contents
     with zipfile.ZipFile(outfile.name, mode="r") as zf:
-        meta_file = zf.open("meta.yml")
-        meta = yaml.safe_load(meta_file)
+        meta_file = zf.open("index.json")
+        meta = json.load(meta_file)
 
         meta_surfaces = meta["surfaces"]
 
         # check number of surfaces and topographies
         for surf_idx, surf in enumerate(surfaces):
             assert meta_surfaces[surf_idx]["name"] == surf.name
-            assert meta_surfaces[surf_idx]["category"] == surf.category
+            # ``index.json`` is written with ``exclude_none=True``, so optional
+            # fields that are ``None`` are omitted rather than serialized as null.
+            assert meta_surfaces[surf_idx].get("category") == surf.category
             assert meta_surfaces[surf_idx]["description"] == surf.description
             assert meta_surfaces[surf_idx]["created_by"]["name"] == surf.created_by.name
-            assert meta_surfaces[surf_idx]["created_by"]["orcid"] == surf.created_by.orcid_id
+            assert meta_surfaces[surf_idx]["created_by"].get("orcid") == surf.created_by.orcid_id
             assert (
                 len(meta_surfaces[surf_idx]["topographies"])
                 == surf.topography_set.count()
@@ -140,11 +142,13 @@ def test_surface_container(example_authors, django_capture_on_commit_callbacks):
             "description",
             "detrend_mode",
             "data_source",
-            "measurement_date",
             "name",
             "unit",
         ]:
             assert topo_meta[field] == getattr(topo2a, field)
+        # JSON has no native date type, so ``measurement_date`` is serialized as
+        # an ISO date string (YAML previously parsed it back into a date object).
+        assert topo_meta["measurement_date"] == str(topo2a.measurement_date)
         assert topo_meta["size"] == [topo2a.size_x, topo2a.size_y]
 
         assert topo_meta["instrument"] == {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import tempfile
 import zipfile
 
 import pytest
-import yaml
+import json
 from freezegun import freeze_time
 from topobank.testing.factories import SurfaceFactory, UserFactory
 
@@ -137,8 +137,8 @@ def test_renew_container(example_pub):
 
     # check whether it's a valid zip file with one surface
     with zipfile.ZipFile(tmpfile.name) as zf:
-        meta_file = zf.open('meta.yml')
-        meta = yaml.safe_load(meta_file)
+        meta_file = zf.open('index.json')
+        meta = json.load(meta_file)
 
         meta_surfaces = meta['surfaces']
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,7 +4,7 @@ import zipfile
 from io import BytesIO
 
 import pytest
-import yaml
+import json
 from django.shortcuts import reverse
 from topobank.testing.factories import UserFactory
 from topobank.testing.utils import assert_in_content
@@ -56,8 +56,8 @@ def test_go_download(api_client, example_pub, handle_usage_statistics):
 
     # open zip file and look into meta file, there should be two surfaces and three topographies
     with zipfile.ZipFile(BytesIO(response.content)) as zf:
-        meta_file = zf.open('meta.yml')
-        meta = yaml.safe_load(meta_file)
+        meta_file = zf.open('index.json')
+        meta = json.load(meta_file)
         assert len(meta['surfaces']) == 1
         assert len(meta['surfaces'][0]['topographies']) == surface.num_topographies()
         assert meta['surfaces'][0]['name'] == surface.name


### PR DESCRIPTION
topobank now writes container metadata to `index.json` (JSON, `exclude_none=True`) instead of the legacy `meta.yml` (YAML). Update the container tests to read `index.json`/`json.load`, use `.get()` for optional fields that may be omitted (`category`, `orcid`), and compare `measurement_date` as an ISO string (JSON has no native date type). Also add an autouse `db` fixture and homogenize `.gitignore`.

Base is `26_split_topobank` since these fixes build on the split work not yet merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)