### PR TITLE
TST: Drop organizations URL include from test URLconf

### DIFF
--- a/publication_test_urls.py
+++ b/publication_test_urls.py
@@ -21,10 +21,6 @@ urlpatterns = [
                     include("topobank_rest_api.users.urls", namespace="users"),
                 ),
                 path(
-                    "organizations/",
-                    include("topobank_rest_api.organizations.urls", namespace="organizations"),
-                ),
-                path(
                     "authorization/",
                     include("topobank_rest_api.authorization.urls", namespace="authorization"),
                 ),


### PR DESCRIPTION
topobank-rest-api removed its organizations app (organization management is gone from this stack), so this test URLconf can no longer include `topobank_rest_api.organizations.urls` — it now errors at test collection. Remove the include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)